### PR TITLE
Adding new public program Ozon from hackerone

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -1887,6 +1887,14 @@
 		"trycourier.com"
 	]
   },
+{
+	"name": "Ozon",
+	"url": "https://hackerone.com/ozon",
+	"bounty": true,
+	"domains": [
+		"www.ozon.ru"
+	]
+  }, 
       {
          "name":"Engel & Völkers Technology GmbH",
          "url":"https://hackerone.com/engel_volkers",

--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -1892,7 +1892,7 @@
 	"url": "https://hackerone.com/ozon",
 	"bounty": true,
 	"domains": [
-		"www.ozon.ru"
+		"ozon.ru"
 	]
   }, 
       {


### PR DESCRIPTION
As per scope only www.ozon.ru is in scope for the program, rest of all subdomains are out of scope.