### PR TITLE
Scope Modification to Cisco

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -206,7 +206,6 @@
 				"ikarem.io",
 				"meraki.com",
 				"network-auth.com",
-				"cisco.com"
 			]
 		},
 		{


### PR DESCRIPTION
If you look at the program scope on Meraki's Bug Bounty Program, it states explicitly that the scope is ikarem, meraki and network-auth.

Cisco root subdomains are way out of scope.