### PR TITLE
Add Alaska Airlines vulnerability reporting page

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -1,6 +1,14 @@
 {
 	"programs": [
 		{
+			"name": "Alaska Airlines",
+			"url": "https://www.alaskaair.com/content/about-us/site-info/report-site-security-issues",
+			"bounty": false,
+			"domains": [
+				"alaskaair.com"
+			]
+		},
+		{
 			"name": "United Airlines",
 			"url": "https://www.united.com/ual/en/us/fly/contact/bugbounty.html",
 			"bounty": true,


### PR DESCRIPTION
Alaska Airlines program, the rules and scopes are on the url page.
I'd like to request access to the choas projectdiscovery.