### PR TITLE
Fix keyname typo on "Warren Brasil" entry

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -5540,7 +5540,7 @@
 			]
         	},
 		{
-			"0name": "Warren Brasil",
+			"name": "Warren Brasil",
 			"url": "https://admin.bughunt.com.br/p/warren-brasil-bug-bounty-program",
 			"bounty": true,
 			"domains": [


### PR DESCRIPTION
keyname should be 'name'