### PR TITLE
Remove space after McDelivery

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -3536,7 +3536,7 @@
       ]
     },
     {
-      "name": "McDelivery ",
+      "name": "McDelivery",
       "url": "https://www.mcdelivery.co.in/More/bugBounty",
       "bounty": true,
       "domains": [


### PR DESCRIPTION
McDelivery was written as "McDelivery " with a trailing space.