### PR TITLE
Boomi is no longer part of Dell

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -1251,7 +1251,6 @@
       "url": "https://bugcrowd.com/dell",
       "bounty": false,
       "domains": [
-        "boomi.com",
         "dell.com",
         "dellemc.com",
         "delltechnologies.com",


### PR DESCRIPTION
See also:

https://bugcrowd.com/dell

> As of September 15, 2021, [Boomi](mailto:security@boomi.com) is no longer a part of Dell Technologies. To report a vulnerability on Boomi, please report findings to Boomi.