### PR TITLE
Update ZOHO bug bounty Scope

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -7641,6 +7641,10 @@
       "bounty": true,
       "swag": false,
       "domains": [
+        "site24x7.com",
+        "manageengine.com",
+        "qntrl.com",
+        "trainercentral.com",
         "zoho.com"
       ]
     },


### PR DESCRIPTION
Add :

*.manageengine.com
*.site24x7.com
*.qntrl.com
*.trainercentral.com

Reference : https://bugbounty.zohocorp.com/bb/info