### PR TITLE
Add "EPAM Bounty" program from hackerone

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -8003,6 +8003,15 @@
       "domains":[
         "uphold.com"
    	]
+   },
+   {
+      "name":"EPAM Bounty",
+      "url":"https://hackerone.com/epam-bbp",
+      "bounty": true,
+      "swag": false,
+      "domains":[
+        "epam.com"
+   	]
    }
   ]
 }


### PR DESCRIPTION
The program also lists other subdomains of epam.com in the scope, but I didn't include them here because they aren't root domains, the full scope as specified in the program description is:
```
training.epam.com
examinator.epam.com
*.epam.com
anywhere.epam.com
cloud.epam.com
access.epam.com
1135407607 (ios app)
com.epam.connect.android (android app)
*.projects.epam.com
```