### PR TITLE
Add Nodeflux and Bukalapak to bugbounty list

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -665,6 +665,18 @@
       ]
     },
     {
+      "name": "Bukalapak",
+      "url": "https://bukalapak.github.io/bukabounty/",
+      "bounty": true,
+      "domains": [
+        "www.bukalapak.com",
+        "m.bukalapak.com",
+        "api.bukalapak.com",
+        "seller.bukalapak.com",
+        "mitra.bukalapak.com"
+      ]
+    },
+    {
       "name": "Bullish",
       "url": "https://bugcrowd.com/bullish",
       "bounty": true,
@@ -4805,6 +4817,15 @@
       "bounty": true,
       "domains": [
         "nozbe.com"
+      ]
+    },
+    {
+      "name": "NodeFlux",
+      "url": "https://www.nodeflux.io/bug-bounty",
+      "bounty": true,
+      "domains": [
+        "cloud.nodeflux.io",
+        "identifai.id"
       ]
     },
     {


### PR DESCRIPTION
I added two new public bugbounty program to .json file for chaos database DNS requirement, I hope it will help you as it helped me.