### PR TITLE
Adding Hackaflag.com.br new programs

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -8208,6 +8208,37 @@
        "cornershop.io",
        "superpal.io"
       ]
+   },
+   {
+     "name":"Grupo DPSP",
+     "url":"https://bugbounty.hackaflag.com.br/hempresa.php?id=6",
+     "bounty": true,
+     "swag": false,
+     "domains":[
+       "dpsp.io",
+       "drogariaspacheco.com.br",
+       "drogariasaopaulo.com.br"
+      ]
+   },
+   {
+    "name":"ELO",
+    "url":"https://bugbounty.hackaflag.com.br/hempresa.php?id=13",
+    "bounty": false,
+    "swag": false,
+    "domains":[
+      "elo.com.br"
+     ]
+   },
+   {
+    "name":"Banco Pan",
+    "url":"https://bugbounty.hackaflag.com.br/hempresa.php?id=14",
+    "bounty": true,
+    "swag": false,
+    "domains":[
+      "bancopan.com.br",
+      "panmais.com.br",
+      "pansolucoes.com.br"
+     ]
    }
   ]
 }


### PR DESCRIPTION
Adding new programs from Hackaflag.com.br:
- ELO;
- Grupo DPSP;
- Banco Pan.