### PR TITLE
Fixed typo for Logitech subdomain

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -4518,7 +4518,7 @@
         "logitechmusic.com",
         "logitechauthorization.com",
         "logitech-channel-marketing.com",
-        "vclogitech.com",
+        "vc.logitech.com",
         "logitech.com.cn",
         "harmonyremote.com",
         "slimdevices.com",

--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -4518,7 +4518,6 @@
         "logitechmusic.com",
         "logitechauthorization.com",
         "logitech-channel-marketing.com",
-        "vc.logitech.com",
         "logitech.com.cn",
         "harmonyremote.com",
         "slimdevices.com",


### PR DESCRIPTION
typo for subdomain meant workflow was not picking up several in-scope subdomains for vc.logitech.com"