### PR TITLE
Update chaos-bugbounty-list.json

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -7049,7 +7049,16 @@
         "thuisbezorgd.nl",
         "pyszne.pl",
         "lieferando.at",
-        "scoober.com"
+        "scoober.com",
+        "citymeal.com",
+        "just-eat.fr",
+        "eat.ch",
+        "just-eat.no",
+        "just-eat.dk",
+        "bistro.sk",
+        "10bis.co.il",
+        "justeattakeaway.com",
+        "takeawayriders.com"
       ]
     },
     {


### PR DESCRIPTION
Add the following domains to the [**Takeaway**](https://bugcrowd.com/takeaway) program
```
citymeal.com
just-eat.fr
eat.ch
just-eat.no
just-eat.dk
bistro.sk
10bis.co.il
justeattakeaway.com
takeawayriders.com
```