### PR TITLE
Update bugbountylist United Airlines

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -7964,10 +7964,11 @@
     },
     {
       "name": "United Airlines",
-      "url": "https://www.united.com/ual/en/us/fly/contact/bugbounty.html",
+      "url": "https://bugcrowd.com/united-vdp",
       "bounty": true,
       "domains": [
-        "united.com"
+        "united.com",
+        "ual.com"
       ]
     },
     {


### PR DESCRIPTION
Changed the United Airlines URL to the bugcrowd VDP which is more frequently updated then the united website one. Included ual.com which is now in scope for testing.