### PR TITLE
Add Avalara VDP

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -8596,6 +8596,25 @@
         "zynga.com",
         "zyngagames.com"
       ]
+    },
+    {
+      "name": "Avalara VDP",
+      "url": "https://hackerone.com/avalara",
+      "bounty": false,
+      "domains": [
+        "avalara.com",
+        "avalara.net",
+        "avalara.io",
+        "papercrane.io",
+        "inposia.com",
+        "netleglobal.com",
+        "crowdreason.com",
+        "track1099.com",
+        "3ce.com",
+        "davosalestax.com",
+        "ttrus.com",
+        "impendulo.com"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Scope : 
*.avalara.com
*.avalara.net
*.avalara.io
*.papercrane.io
*.inposia.com
*.netleglobal.com
*.crowdreason.com
*.track1099.com
*.3ce.com
*.davosalestax.com
*.ttrus.com
*.impendulo.com


Reference : https://hackerone.com/avalara?type=team