### PR TITLE
Remove 'Edmodo' BB program

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -2009,14 +2009,6 @@
       ]
     },
     {
-      "name": "Edmodo",
-      "url": "https://support.edmodo.com/hc/en-us/articles/360035475733-Bug-Bounty-Guidelines",
-      "bounty": true,
-      "domains": [
-        "edmodo.com"
-      ]
-    },
-    {
       "name": "Eerste Kamer",
       "url": "https://www.eerstekamer.nl/begrip/responsible_disclosure",
       "bounty": false,


### PR DESCRIPTION
Edmodo company closed since august 2022
sources:
https://en.wikipedia.org/wiki/Edmodo
https://www.edsurge.com/news/2022-08-16-popular-k-12-tool-edmodo-shuts-down