### PR TITLE
Addition of Walmart.com VDP

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -9092,6 +9092,15 @@
       ]
     },
     {
+      "name":"Walmart Corporation",
+      "url":"https://corporate.walmart.com/article/responsible-disclosure-policy",
+      "bounty": false,
+      "swag": false,
+      "domains":[
+         "walmart.com"
+      ]
+    },
+    {
       "name": "Warren Brasil",
       "url": "https://admin.bughunt.com.br/program/detail?5eeb6b1b660ac82f7cdaf7e0",
       "bounty": true,


### PR DESCRIPTION
Per https://corporate.walmart.com/article/responsible-disclosure-policy creating the addition of the Walmart VDP with the root domain of walmart.com. I'm sure there are additional tld's to add, but I wanted to kick this off with walmart.com as they have no detailed scope in their VDP brief.