### PR TITLE
Add Western Digital's VDP

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -9056,6 +9056,15 @@
       ]
     },
     {
+      "name": "Western Digital",
+      "url": "https://www.westerndigital.com/en-ap/support/product-security/vulnerability-disclosure-policy",
+      "bounty": false,
+      "domains": [
+        "westerndigital.com",
+        "wd.com"
+      ]
+    },
+    {
       "name": "Western Union",
       "url": "https://bugcrowd.com/westernunion",
       "bounty": true,


### PR DESCRIPTION
Reference: https://www.westerndigital.com/en-ap/support/product-security/vulnerability-disclosure-policy

"We also welcome vulnerability reports on all our web pages and cloud services."