### PR TITLE
Updated a missing domain Goldman Sachs (nextcapital.com)

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -2617,7 +2617,8 @@
         "marcus.com",
         "rocaton.com",
         "unitedcp.com",
-        "goldmansachsindices.com"
+        "goldmansachsindices.com",
+        "nextcapital.com"
       ]
     },
     {


### PR DESCRIPTION
![image](https://github.com/projectdiscovery/public-bugbounty-programs/assets/22111782/08af9931-ef53-44e3-9b2c-7281e61249d5)
