### PR TITLE
Update chaos-bugbounty-list.json

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -8055,8 +8055,8 @@
       ]
     },
     {
-      "name": "Takeaway",
-      "url": "https://bugcrowd.com/takeaway",
+      "name": "Just Eat Takeaway.com",
+      "url": "https://bugcrowd.com/justeattakeaway",
       "bounty": true,
       "domains": [
         "lieferando.de",
@@ -8074,7 +8074,19 @@
         "bistro.sk",
         "10bis.co.il",
         "justeattakeaway.com",
-        "takeawayriders.com"
+        "takeawayriders.com",
+        "je-apis.com",
+        "just-data.io",
+        "just-eat.co.uk",
+        "just-eat.com",
+        "just-eat.es",
+        "just-eat.ie",
+        "just-eat.io",
+        "just-eat.it",
+        "justeat-int.com",
+        "menulog.co.nz",
+        "menulog.com.au",
+        "skipthedishes.com"
       ]
     },
     {


### PR DESCRIPTION
Just Eat Takeaway changed it's Bugcrowd URL and added more targets to inscope.