### PR TITLE
Changes for Pornhub

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -6758,11 +6758,18 @@
     },
     {
       "name": "Pornhub",
-      "url": "https://hackerone.com/pornhub",
+      "url": "https://bugcrowd.com/aylo-mbb-og",
       "bounty": true,
       "domains": [
         "pornhub.com",
-        "pornhubpremium.com"
+        "pornhubpremium.com",
+        "tube8.com",
+        "redtube.com",
+        "redtubepremium.com",
+        "youporn.com",
+        "youpornpremium.com",
+        "pornmd.com",
+        "thumbzilla.com"
       ]
     },
     {


### PR DESCRIPTION
Pornhub have migrated to Bugcrowd from Hackerone.
I have added all the inscope targets (while ignoring those occurring explicity as OOS).