### PR TITLE
Update chaos-bugbounty-list.json

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -6796,8 +6796,22 @@
       "url": "https://hackerone.com/pornhub",
       "bounty": true,
       "domains": [
+        "tube8.com",
         "pornhub.com",
-        "pornhubpremium.com"
+        "pornhubpremium.com",
+        "redtube.com",
+        "redtubepremium.com",
+        "youporn.com",
+        "youpornpremium.com",
+        "pornmd.com",
+        "thumbzilla.com",
+        "modelhub.com",
+        "pronstore.com",
+        "tube8vip.com",
+        "pornhub.org",
+        "pornhubapparel.com",
+        "tube8.fr",
+        "tube8.es"
       ]
     },
     {
@@ -8460,16 +8474,6 @@
       "bounty": false,
       "domains": [
         "tu-chemniz.de"
-      ]
-    },
-    {
-      "name": "Tube8",
-      "url": "https://hackerone.com/tube8",
-      "bounty": true,
-      "domains": [
-        "tube8.com",
-        "tube8.es",
-        "tube8.fr"
       ]
     },
     {

--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -6793,7 +6793,7 @@
     },
     {
       "name": "Pornhub",
-      "url": "https://hackerone.com/pornhub",
+      "url": "https://bugcrowd.com/aylo-mbb-og",
       "bounty": true,
       "domains": [
         "tube8.com",
@@ -7112,14 +7112,6 @@
       "bounty": true,
       "domains": [
         "redoxengine.com"
-      ]
-    },
-    {
-      "name": "Redtube",
-      "url": "https://hackerone.com/redtube",
-      "bounty": true,
-      "domains": [
-        "redtube.com"
       ]
     },
     {


### PR DESCRIPTION
1. Removed tube8 which has been disabled on Hackerone.
2. Removed redtube which has been disabled on Hackerone.
3. Pornhub recently moved to Bugcrowd - so the URL for the program has been updated accordingly.
4. All domains from Pornhub (including the OOS as in Bugcrowd), and those for tube8 and redtube as per the json file have been merged into one (since tube8.com and redtube.com are in scope in Bugcrowd, which implies they have been unified).
5. The OOS is because Aylo Freesites Ltd (“Pornhub”) can check valid submissions on a case by case basis.