### PR TITLE
Fix Arrival Rewards

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -494,8 +494,8 @@
     {
       "name": "Arrival",
       "url": "https://arrival.com/legal/security#purpose",
-      "bounty": true,
-      "swag": false,
+      "bounty": false,
+      "swag": true,
       "domains": [
         "arrival.com",
         "arrival.co"


### PR DESCRIPTION
> "Arrival is no longer able to offer monitoray rewards for bugs and vulnerabilities reported, however we happy to provide kudos. In some cases, we may also offer Arrival branded hoodies and T-shirts."

This PR updates the bug bounty list to the reflect Arrival's bug bounty terms.
