### PR TITLE
Update yandex domains, include new .cloud tld

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -9650,6 +9650,7 @@
         "yandex.by",
         "yandex.st",
         "yandex.net",
+        "yandex.cloud",
         "ya.ru",
         "yandex-bank.net",
         "kinopoisk.ru",


### PR DESCRIPTION
Yandex moved public resources of its cloud to a new domain zone - `yandex.cloud`, which is now used instead of `cloud.yandex.ru|.com`. Still included in the same bugbounty program.