### PR TITLE
Feat: Added cava.com to public bug-bounty list

### DIFF
--- a/chaos-bugbounty-list.json
+++ b/chaos-bugbounty-list.json
@@ -1181,6 +1181,15 @@
       ]
     },
     {
+      "name": "Cava",
+      "url": "http://cava.com/.well-known/security.txt",
+      "bounty": false,
+      "swag": false,
+      "domains": [
+          "cava.com"
+        ]
+    },
+    {
       "name": "CBRE",
       "url": "https://hackerone.com/cbre",
       "bounty": false,


### PR DESCRIPTION
The following program has been added to the public bug bounty list and resolve #1086 

```json
{
   "name": "Cava",
   "url": "http://cava.com/.well-known/security.txt",
   "bounty": false,
   "swag": false,
   "domains": [
         "cava.com"
    ]
}
```