### PR TITLE
Add Zabbix bug bounty program

### DIFF
--- a/src/data.yaml
+++ b/src/data.yaml
@@ -7321,6 +7321,11 @@ programs:
       - meebits.app
       - cryptopunks.app
       - mdvmm.xyz
+  - name: Zabbix
+    url: https://hackerone.com/zabbix
+    bounty: true
+    domains:
+      - zabbix.com
   - name: Zapier
     url: https://zapier.com/engineering/bug-bounty-program/
     bounty: true


### PR DESCRIPTION
## Summary

- Adds Zabbix's public HackerOne bug bounty program to `src/data.yaml`.
- Regenerates `dist/data.json` from the updated YAML.

## Validation

- Verified `dist/data.json` contains the new Zabbix entry with `bounty: true` and `domains: ["zabbix.com"]`.
- Checked that `zabbix.com` is not duplicated in the generated domain list.

## References

- https://hackerone.com/zabbix
- https://www.zabbix.com/pr/pr439
